### PR TITLE
DLS-12306 | Update test runner and changes required for migration/upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,5 +9,9 @@ lazy val root = (project in file("."))
     // Enabling sbt-auto-build plugin provides DefaultBuildSettings with default `testOptions` from `sbt-settings` plugin.
     // These testOptions are not compatible with `sbt gatling:test`. So we have to override testOptions here.
     Test / testOptions := Seq.empty,
-    libraryDependencies ++= Dependencies.test
+    libraryDependencies ++= Dependencies.test,
+    Gatling / javaOptions ++= Seq(
+      "--add-opens=java.base/java.lang=ALL-UNNAMED",
+      "--add-opens=java.base/java.io=ALL-UNNAMED"
+    ) // Tmp inclusion of above args to handle compatibility with Java 21
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   val test = Seq(
-    "uk.gov.hmrc" %% "performance-test-runner" % "6.1.0"
+    "uk.gov.hmrc" %% "performance-test-runner" % "6.2.0"
   ).map(_ % Test)
 
 }

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/AuthRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/AuthRequests.scala
@@ -30,7 +30,7 @@ object AuthRequests extends BaseRequest {
     """<td data-session-id="authToken" style="word-break: break-all">
       |            <code style="border: none">([^"]+)</code>""".stripMargin
 
-  def saveBearerTokenFromBody(): CheckBuilder[RegexCheckType, String, String] = regex(_ => bearerTokenPattern).saveAs("bearerToken")
+  def saveBearerTokenFromBody(): CheckBuilder[RegexCheckType, String] = regex(_ => bearerTokenPattern).saveAs("bearerToken")
 
   lazy val navigateToAuth: HttpRequestBuilder =
     http("Navigate to Auth wizard")
@@ -51,9 +51,9 @@ object AuthRequests extends BaseRequest {
       .formParam("enrolment[0].state", "Activated")
       .check(status.is(303))
 
-  def createRegistrationsAuthSession: HttpRequestBuilder = createAuthSession("${RegistrationsUTR}")
-  def createReturnsAuthSession: HttpRequestBuilder = createAuthSession("${ReturnsUTR}")
-  def createVariationsAuthSession: HttpRequestBuilder = createAuthSession("${VariationsUTR}")
+  def createRegistrationsAuthSession: HttpRequestBuilder = createAuthSession("#{RegistrationsUTR}")
+  def createReturnsAuthSession: HttpRequestBuilder = createAuthSession("#{ReturnsUTR}")
+  def createVariationsAuthSession: HttpRequestBuilder = createAuthSession("#{VariationsUTR}")
 
   lazy val navigateToAuthSession: HttpRequestBuilder =
     http("Navigate to Auth Session page")

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/BaseRequest.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/BaseRequest.scala
@@ -30,13 +30,13 @@ trait BaseRequest extends ServicesConfiguration {
 
   val csrfPattern = """<input type="hidden" name="csrfToken" value="([^"]+)""""
 
-  def saveCsrfToken(): CheckBuilder[RegexCheckType, String, String] =
+  def saveCsrfToken(): CheckBuilder[RegexCheckType, String] =
     regex(_ => csrfPattern).optional.saveAs("csrfToken")
 
-  def saveCookie(): CheckBuilder[HttpHeaderRegexCheckType, Response, String] =
+  def saveCookie(): CheckBuilder[HttpHeaderRegexCheckType, Response] =
     headerRegex("Set-Cookie", "mdtp=(.*)").optional.saveAs("cookie")
 
-  def absoluteRedirectTransform(baseUrl: String): (String => String) = {
+  def absoluteRedirectTransform(baseUrl: String): String => String = {
     redirectUrl: String => {
       if (redirectUrl.startsWith("/")) {
         baseUrl + redirectUrl

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILAccountRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILAccountRequests.scala
@@ -47,7 +47,7 @@ object SDILAccountRequests extends ServicesConfiguration {
   def postAccountHomePageStartReturn: HttpRequestBuilder = {
     http(s"POST account-home")
       .post(s"$baseAccountFrontEndUrl/$accountFrontEndRoute/start-a-return": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/start-a-return": String))
   }
@@ -62,7 +62,7 @@ object SDILAccountRequests extends ServicesConfiguration {
 
   def getAccountHomePageStartReturn2: HttpRequestBuilder = {
     http(s"GET account-home-start-return-2")
-      .get("${startReturnUrl}")
+      .get("#{startReturnUrl}")
       .check(status.is(303))
       .check(saveCsrfToken())
   }
@@ -70,7 +70,7 @@ object SDILAccountRequests extends ServicesConfiguration {
   def postAccountHomePageTellHMRCAboutAChange: HttpRequestBuilder = {
     http(s"POST account-home")
       .post(s"$baseAccountFrontEndUrl/$accountFrontEndRoute/make-a-change": String)
-      //.formParam("csrfToken", s"$${csrfToken}")
+      //.formParam("csrfToken", s"#{csrfToken}")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/start-a-return": String))
   }

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILRegistrationJourneyRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILRegistrationJourneyRequests.scala
@@ -17,13 +17,13 @@
 package uk.gov.hmrc.perftests.sdil
 
 import io.gatling.http.request.builder.HttpRequestBuilder
-import uk.gov.hmrc.perftests.sdil.AuthRequests.{createAuthSession, createRegistrationsAuthSession, navigateToAuth, navigateToAuthSession}
-import uk.gov.hmrc.perftests.sdil.SDILRegistrationRequests.{getPage, postPage, _}
+import uk.gov.hmrc.perftests.sdil.AuthRequests.{createRegistrationsAuthSession, navigateToAuth, navigateToAuthSession}
+import uk.gov.hmrc.perftests.sdil.SDILRegistrationRequests._
 import uk.gov.hmrc.perftests.sdil.SetupRequests._
 
 trait SDILRegistrationJourneyRequests {
 
-  val resetDataAndSignin = Seq(
+  val resetDataAndSignin: Seq[HttpRequestBuilder] = Seq(
     resetPending,
 //    resetReturns,
     resetRegistrations,
@@ -103,8 +103,8 @@ trait SDILRegistrationJourneyRequests {
     )
   }
 
-  val sdilRegisterAnswerYesToAllForLargeProducerJourneyRequests = sdilRegisterAnswerYesToAllForGivenProducerTypeJourneyRequests("large")
-  val sdilRegisterAnswerYesToAllForSmallProducerJourneyRequests = sdilRegisterAnswerYesToAllForGivenProducerTypeJourneyRequests("small")
-  val sdilRegisterAnswerYesToAllForNoneProducerJourneyRequests = sdilRegisterAnswerYesToAllForGivenProducerTypeJourneyRequests("none")
+  val sdilRegisterAnswerYesToAllForLargeProducerJourneyRequests: Seq[HttpRequestBuilder] = sdilRegisterAnswerYesToAllForGivenProducerTypeJourneyRequests("large")
+  val sdilRegisterAnswerYesToAllForSmallProducerJourneyRequests: Seq[HttpRequestBuilder] = sdilRegisterAnswerYesToAllForGivenProducerTypeJourneyRequests("small")
+  val sdilRegisterAnswerYesToAllForNoneProducerJourneyRequests: Seq[HttpRequestBuilder] = sdilRegisterAnswerYesToAllForGivenProducerTypeJourneyRequests("none")
 
 }

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILRegistrationRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILRegistrationRequests.scala
@@ -47,7 +47,7 @@ object SDILRegistrationRequests extends ServicesConfiguration {
   def postFormlessPage(url: String, redirectUrl: String = ""): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .check(status.is(303))
       .check(header("Location").is(s"/$frontEndRoute$redirectUrl": String))
   }
@@ -55,7 +55,7 @@ object SDILRegistrationRequests extends ServicesConfiguration {
   def postPage(url: String, body: String, redirectUrl: String = ""): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", body)
       .check(status.is(303))
       .check(header("Location").is(s"/$frontEndRoute$redirectUrl": String))
@@ -64,14 +64,14 @@ object SDILRegistrationRequests extends ServicesConfiguration {
   def postPageRedirectToAddressLookup(url: String, body: String, redirectUrl: String = ""): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", body)
       .check(status.is(303))
       .check(headerRegex("Location", s"(.*)$frontEndRoute/off-ramp$redirectUrl(.*)": String))
       .check(header("Location").saveAs("addressOffRampUrl"))
   }
 
-  def getPackagingSiteNamePage(): HttpRequestBuilder = {
+  def getPackagingSiteNamePage: HttpRequestBuilder = {
     http(s"POST packaging-site-name")
       .get(s"$baseFrontEndUrl/$frontEndRoute/packaging-site-name": String)
       .check(status.is(303))
@@ -82,15 +82,15 @@ object SDILRegistrationRequests extends ServicesConfiguration {
     println("here3")
     http(s"POST packaging-site-name")
       .post(s"$baseFrontEndUrl/$frontEndRoute/packaging-site-name": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("packagingSiteName", "pSiteName")
       .check(status.is(303))
       .check(headerRegex("Location", s"(.*)$frontEndRoute/off-ramp$redirectUrl(.*)": String))
   }
 
   def getAddressRampOffPage(redirectUrl: String): HttpRequestBuilder = {
-    http(s"GET $${addressOffRampUrl}")
-      .get(s"$${addressOffRampUrl}": String)
+    http(s"GET #{addressOffRampUrl}")
+      .get(s"#{addressOffRampUrl}": String)
       .check(status.is(303))
       .check(saveCsrfToken())
       .check(header("Location").is(s"/$frontEndRoute$redirectUrl": String))
@@ -99,7 +99,7 @@ object SDILRegistrationRequests extends ServicesConfiguration {
   def postLitresPage(url: String, redirectUrl: String = ""): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("lowBand", "100")
       .formParam("highBand", "100")
       .check(status.is(303))
@@ -109,7 +109,7 @@ object SDILRegistrationRequests extends ServicesConfiguration {
   def postContactDetailsPage(redirectUrl: String = ""): HttpRequestBuilder = {
     http("POST contact-details")
       .post(s"$baseFrontEndUrl/$frontEndRoute/contact-details": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("fullName", "Some Name")
       .formParam("position", "Manager")
       .formParam("phoneNumber", "01234567890")
@@ -126,7 +126,7 @@ object SDILRegistrationRequests extends ServicesConfiguration {
 
     http("POST start-date")
       .post(s"$baseFrontEndUrl/$frontEndRoute/start-date": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("startDate.day", startDay)
       .formParam("startDate.month", startMonth)
       .formParam("startDate.year", startYear)
@@ -137,7 +137,7 @@ object SDILRegistrationRequests extends ServicesConfiguration {
   def postCheckYourAnswersPage: HttpRequestBuilder = {
     http("POST check-your-anwers")
       .post(s"$baseFrontEndUrl/$frontEndRoute/check-your-answers": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .check(status.is(303))
       .check(header("Location").is(s"/$frontEndRoute/registration-confirmation": String))
   }

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnJourneyRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnJourneyRequests.scala
@@ -21,6 +21,7 @@ import uk.gov.hmrc.perftests.sdil.AuthRequests.{createReturnsAuthSession, naviga
 import uk.gov.hmrc.perftests.sdil.SDILAccountRequests.{getAccountHomePage, getAccountHomePageStartReturn1, getAccountHomePageStartReturn2}
 import uk.gov.hmrc.perftests.sdil.SDILReturnsRequests._
 import uk.gov.hmrc.perftests.sdil.SetupRequests._
+
 trait SDILReturnJourneyRequests {
 
   val sdilReturnJourney1Requests: Seq[HttpRequestBuilder] = Seq(

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnsRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnsRequests.scala
@@ -47,7 +47,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postOwnBrandsPackagedAtOwnSitesPage: HttpRequestBuilder = {
     http("POST own-brands-packaged-at-own-sites")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/own-brands-packaged-at-own-sites": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", "true")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/how-many-own-brands-packaged-at-own-sites": String))
@@ -63,7 +63,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postHowManyOwnBrandsPackagedAtOwnSitesPage: HttpRequestBuilder = {
     http("POST how-many-own-brands-packaged-at-own-sites")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/how-many-own-brands-packaged-at-own-sites": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("lowBand", "100")
       .formParam("highBand", "100")
       .check(status.is(303))
@@ -80,7 +80,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postPackagedAsContractPackerPage: HttpRequestBuilder = {
     http("POST packaged-as-contract-packer")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/packaged-as-contract-packer": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", "true")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/how-many-packaged-as-contract-packer": String))
@@ -96,7 +96,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postHowManyPackagedAsContractPackerPage: HttpRequestBuilder = {
     http("POST how-many-packaged-as-contract-packer")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/how-many-packaged-as-contract-packer": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("lowBand", "100")
       .formParam("highBand", "100")
       .check(status.is(303))
@@ -113,7 +113,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postExemptionsForSmallProducersPage: HttpRequestBuilder = {
     http("POST exemptions-for-small-producers")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/exemptions-for-small-producers": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", "true")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/add-small-producer": String))
@@ -130,7 +130,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postAddSmallProducerPage: HttpRequestBuilder = {
     http("POST add-small-producer")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/add-small-producer": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("producerName", "Fake Producer")
       .formParam("referenceNumber", "XPSDIL000000161")
       .formParam("lowBand", "1000")
@@ -149,7 +149,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postSmallProducerDetailsPage: HttpRequestBuilder = {
     http("POST small-producer-details")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/small-producer-details": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", "false")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/brought-into-uk": String))
@@ -165,7 +165,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postBroughtIntoUKPage: HttpRequestBuilder = {
     http("POST brought-into-uk")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/brought-into-uk": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", "true")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/how-many-brought-into-uk": String))
@@ -181,7 +181,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postHowManyBroughtIntoUKPage: HttpRequestBuilder = {
     http("POST how-many-brought-into-uk")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/how-many-brought-into-uk": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("lowBand", "100")
       .formParam("highBand", "100")
       .check(status.is(303))
@@ -198,7 +198,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postBroughtIntoUKFromSmallProducersPage: HttpRequestBuilder = {
     http("POST brought-into-uk-from-small-producers")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/brought-into-uk-from-small-producers": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", "true")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/how-many-into-uk-small-producers": String))
@@ -214,7 +214,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postHowManyBroughtIntoUKFromSmallProducersPage: HttpRequestBuilder = {
     http("POST how-many-into-uk-small-producers")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/how-many-into-uk-small-producers": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("lowBand", "100")
       .formParam("highBand", "100")
       .check(status.is(303))
@@ -231,7 +231,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postClaimCreditsForExportsPage: HttpRequestBuilder = {
     http("POST claim-credits-for-exports")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/claim-credits-for-exports": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", "true")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/how-many-credits-for-exports": String))
@@ -247,7 +247,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postHowManyCreditsForExportsPage: HttpRequestBuilder = {
     http("POST how-many-credits-for-exports")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/how-many-credits-for-exports": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("lowBand", "100")
       .formParam("highBand", "100")
       .check(status.is(303))
@@ -264,7 +264,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postClaimCreditsForLostDamagedPage: HttpRequestBuilder = {
     http("POST claim-credits-for-lost-damaged")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/claim-credits-for-lost-damaged": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", "true")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/how-many-credits-for-lost-damaged": String))
@@ -280,7 +280,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postHowManyCreditsForLostDamagedPage: HttpRequestBuilder = {
     http("POST how-many-credits-for-lost-damaged")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/how-many-credits-for-lost-damaged": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("lowBand", "100")
       .formParam("highBand", "100")
       .check(status.is(303))
@@ -297,7 +297,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postReturnChangeRegistrationPage: HttpRequestBuilder = {
     http("POST claim-credits-for-lost-damaged")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/return-change-registration": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", "false")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/ask-secondary-warehouses-in-return": String))
@@ -313,7 +313,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postPackAtBusinessAddressChangePage: HttpRequestBuilder = {
     http("POST pack-at-business-address")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/pack-at-business-address-in-return": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", "true")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/packaging-site-details": String))
@@ -329,7 +329,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postProductionSiteDetailsPage: HttpRequestBuilder = {
     http("POST packaging-site-details")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/packaging-site-details": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", "false")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/check-your-answers": String))
@@ -353,7 +353,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postSecondaryWarehouseDetailsPage: HttpRequestBuilder = {
     http("POST secondary-warehouse-details")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/secondary-warehouse-details": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", "false")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/check-your-answers": String))
@@ -376,7 +376,7 @@ object SDILReturnsRequests extends ServicesConfiguration {
   def postCheckYourAnswersPage: HttpRequestBuilder = {
     http("POST check-your-anwers")
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/check-your-answers": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .check(status.is(303))
       .check(header("Location").is(s"/$returnsFrontEndRoute/return-sent": String))
   }

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILSimulation.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILSimulation.scala
@@ -16,12 +16,7 @@
 
 package uk.gov.hmrc.perftests.sdil
 
-import io.gatling.http.request.builder.HttpRequestBuilder
 import uk.gov.hmrc.performance.simulation.PerformanceTestRunner
-import uk.gov.hmrc.perftests.sdil.AuthRequests._
-import uk.gov.hmrc.perftests.sdil.SDILReturnsRequests._
-import uk.gov.hmrc.perftests.sdil.SDILVariationsRequests.{getPage, postCancelDatePage, postContactDetailsAddPage, postFormlessPage, postLitresPage, postPage}
-import uk.gov.hmrc.perftests.sdil.SetupRequests._
 
 class SDILSimulation extends PerformanceTestRunner
   with SDILRegistrationJourneyRequests

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILVariationsJourneyRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILVariationsJourneyRequests.scala
@@ -20,7 +20,6 @@ import io.gatling.http.request.builder.HttpRequestBuilder
 import uk.gov.hmrc.perftests.sdil.AuthRequests.{createVariationsAuthSession, navigateToAuth, navigateToAuthSession}
 import uk.gov.hmrc.perftests.sdil.SDILAccountRequests.getAccountHomePage
 import uk.gov.hmrc.perftests.sdil.SDILVariationsRequests._
-import uk.gov.hmrc.perftests.sdil.SetupRequests.{resetPending, resetReturns, resetReturnsUserAnswers, sdilReturnsCollectionReset}
 
 trait SDILVariationsJourneyRequests {
 
@@ -88,7 +87,7 @@ trait SDILVariationsJourneyRequests {
     postChangeSitesOnlyPage("change-registered-details")
   ) ++ getRemovePackingSiteRequests ++ Seq(
     getPage("change-registered-details/warehouse-details"),
-    postPackagingSiteDetailsPage("change-registered-details/warehouse-details", "true", "change-registered-details/warehouse-details"),
+    postPackagingSiteDetailsPage("change-registered-details/warehouse-details", "true"),
     getPage("change-registered-details/warehouse-details"),
     getPage("change-registered-details/warehouse-details/remove/0"),
     postPage("change-registered-details/warehouse-details/remove/0", "true", "change-registered-details/warehouse-details"),

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILVariationsRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILVariationsRequests.scala
@@ -21,7 +21,6 @@ import io.gatling.http.Predef._
 import io.gatling.http.request.builder.HttpRequestBuilder
 import uk.gov.hmrc.performance.conf.ServicesConfiguration
 import uk.gov.hmrc.perftests.sdil.AuthRequests.{hasPackagingSites, saveCsrfToken}
-import uk.gov.hmrc.perftests.sdil.SDILVariationsRequests.getPage
 
 import java.time.LocalDate
 
@@ -40,7 +39,7 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postFormlessPage(url: String, redirectUrl: String = ""): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .check(status.is(303))
       .check(header("Location").is(s"/$frontEndRoute/$redirectUrl": String))
   }
@@ -48,7 +47,7 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postPage(url: String, body: String, redirectUrl: String = ""): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", body)
       .check(status.is(303))
       .check(header("Location").is(s"/$frontEndRoute/$redirectUrl": String))
@@ -57,16 +56,16 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postPage2(url: String, body: String, redirectUrl: String = ""): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("id", body)
       .check(status.is(303))
       .check(header("Location").is(s"/$frontEndRoute/$redirectUrl": String))
   }
 
-  def postPackagingSiteDetailsPage(url: String, body: String, redirectUrl: String = ""): HttpRequestBuilder = {
+  def postPackagingSiteDetailsPage(url: String, body: String): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", body)
       .check(status.is(303))
   }
@@ -74,7 +73,7 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postPageRedirectToAddressLookup(url: String, body: String, redirectUrl: String = ""): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value", body)
       .check(status.is(303))
       .check(headerRegex("Location", s"(.*)$frontEndRoute/off-ramp/$redirectUrl(.*)": String))
@@ -83,17 +82,17 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postChangeContactDetailsOnlyPage(url: String): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value[1]", "contactDetails")
       .check(status.is(303))
       .check(header("Location").is(s"/$frontEndRoute/change-registered-details/contact-details-add": String))
   }
 
   def getAddPackingSiteRequests: Seq[HttpRequestBuilder] = {
-    if(hasPackagingSites(s"$$changeSitesUrl")) {
+    if(hasPackagingSites(s"#changeSitesUrl")) {
       Seq(
         getPage("change-registered-details/packaging-site-details"),
-        postPackagingSiteDetailsPage("change-registered-details/packaging-site-details", "true", "change-registered-details/packaging-site-details"),
+        postPackagingSiteDetailsPage("change-registered-details/packaging-site-details", "true"),
         getPage("change-registered-details/packaging-site-details"),
         postPage("change-registered-details/packaging-site-details", "false", "change-registered-details/warehouse-details")
       )
@@ -101,13 +100,13 @@ object SDILVariationsRequests extends ServicesConfiguration {
   }
 
   def getRemovePackingSiteRequests: Seq[HttpRequestBuilder] = {
-    if (hasPackagingSites(s"$$changeSitesUrl")) {
+    if (hasPackagingSites(s"#changeSitesUrl")) {
         Seq(
           getPage("change-registered-details/packaging-site-details"),
-          postPackagingSiteDetailsPage("change-registered-details/packaging-site-details", "true", "change-registered-details/packaging-site-details"),
+          postPackagingSiteDetailsPage("change-registered-details/packaging-site-details", "true"),
           getPage("change-registered-details/packaging-site-details"),
           getPage ("change-registered-details/packaging-site-details/remove/0"),
-          postPackagingSiteDetailsPage("change-registered-details/packaging-site-details/remove/0", "true", "change-registered-details/packaging-site-details"),
+          postPackagingSiteDetailsPage("change-registered-details/packaging-site-details/remove/0", "true"),
           getPage("change-registered-details/packaging-site-details"),
           postPage("change-registered-details/packaging-site-details", "false", "change-registered-details/warehouse-details")
         )
@@ -119,7 +118,7 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postChangeSitesOnlyPage(url: String): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value[0]", "sites")
       .check(status.is(303))
       .check(header("Location").in(s"/$frontEndRoute/change-registered-details/packaging-site-details": String,
@@ -130,7 +129,7 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postChangeBusinessDetailsOnlyPage(url: String): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value[2]", "businessDetails")
       .check(status.is(303))
       .check(header("Location").is(s"/$frontEndRoute/change-registered-details/": String))
@@ -139,7 +138,7 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postChangeAllPage(url: String): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("value[0]", "sites")
       .formParam("value[1]", "contactDetails")
       .formParam("value[2]", "businessDetails")
@@ -150,7 +149,7 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postLitresPage(url: String, redirectUrl: String = "", highBand: String = "100", lowBand: String = "100"): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("litres.lowBand", lowBand)
       .formParam("litres.highBand", highBand)
       .check(status.is(303))
@@ -160,7 +159,7 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postLitresPageNxtPagePackagingSites(url: String, highBand: String = "100", lowBand: String = "100"): HttpRequestBuilder = {
     http(s"POST $url")
       .post(s"$baseFrontEndUrl/$frontEndRoute/$url": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("litres.lowBand", lowBand)
       .formParam("litres.highBand", highBand)
       .check(status.is(303))
@@ -170,7 +169,7 @@ object SDILVariationsRequests extends ServicesConfiguration {
   }
 
   def getAddPackingSiteIfRequiredOrNoUpdateRequests: Seq[HttpRequestBuilder] = {
-    if (hasPackagingSites(s"$$updatePackagingSitesUrl")) {
+    if (hasPackagingSites(s"#updatePackagingSitesUrl")) {
       Seq(
         getPage("change-activity/packaging-site-details"),
         postPage("change-activity/packaging-site-details", "false", "change-activity/secondary-warehouse-details")
@@ -186,7 +185,7 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postContactDetailsAddPage(redirectUrl: String = ""): HttpRequestBuilder = {
     http("POST change-registered-details/contact-details-add")
       .post(s"$baseFrontEndUrl/$frontEndRoute/change-registered-details/contact-details-add": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("fullName", "Some Name")
       .formParam("position", "Manager")
       .formParam("phoneNumber", "01234567890")
@@ -198,7 +197,7 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postCancelDatePage: HttpRequestBuilder = {
     http("POST cancel-registration/date")
       .post(s"$baseFrontEndUrl/$frontEndRoute/cancel-registration/date": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("cancelRegistrationDate.day", (LocalDate.now().plusDays(2).getDayOfMonth).toString)
       .formParam("cancelRegistrationDate.month", (LocalDate.now().plusDays(2).getMonthValue).toString)
       .formParam("cancelRegistrationDate.year", (LocalDate.now().plusDays(2).getYear).toString)
@@ -209,7 +208,7 @@ object SDILVariationsRequests extends ServicesConfiguration {
   def postAddSmallProducerPage: HttpRequestBuilder = {
     http("POST add-small-producer")
       .post(s"$baseFrontEndUrl/$frontEndRoute/correct-return/add-small-producer": String)
-      .formParam("csrfToken", s"$${csrfToken}")
+      .formParam("csrfToken", s"#{csrfToken}")
       .formParam("producerName", "Fake Producer")
       .formParam("referenceNumber", "XZSDIL000000234")
       .formParam("litres.lowBand", "1000")

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SetupRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SetupRequests.scala
@@ -56,7 +56,7 @@ object SetupRequests extends BaseRequest {
       .get(s"$baseBackendUrl/$backendRoute/sdilReturnsCollectionReset": String)
   }
 
-  def resetReturnsUserAnswers(sdilRef: String = "${SDILRef}"): HttpRequestBuilder = {
+  def resetReturnsUserAnswers(sdilRef: String = "#{SDILRef}"): HttpRequestBuilder = {
     http(s"GET user-answers $sdilRef")
       .get(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/test-only/user-answers/$sdilRef": String)
   }


### PR DESCRIPTION
- SDIL FE bootstrap upgrade was done, which requires us to update test-runner
- PR addresses that and also required changes for new version of runner and gatling
- Current runner version is having issue with Java 21 as mentioned in migration guide. Rather than reverting to 11 - included additional JVM args that we can remove later once runner compatibility with java 21 is fixed