### PR TITLE
DLS-12982 Stabilise returns perf test small producer reference selection

### DIFF
--- a/src/test/resources/services-local.conf
+++ b/src/test/resources/services-local.conf
@@ -35,5 +35,6 @@ services {
     soft-drinks-industry-levy-returns-frontend.port = 8703
     soft-drinks-industry-levy-registration-frontend.port = 8706
     soft-drinks-industry-levy.port = 8701
+    soft-drinks-industry-levy-stub.port = 8702
     auth-login-stub.port = 9949
 }

--- a/src/test/resources/services.conf
+++ b/src/test/resources/services.conf
@@ -61,6 +61,12 @@ services {
       port = 443
   }
 
+  soft-drinks-industry-levy-stub{
+      protocol = https
+      host = soft-drinks-industry-levy-stub.protected.mdtp
+      port = 443
+  }
+
   auth-login-stub{
       protocol = https
       host = www.staging.tax.service.gov.uk

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILAccountRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILAccountRequests.scala
@@ -52,6 +52,8 @@ object SDILAccountRequests extends BaseRequest {
       .get(s"$baseAccountFrontEndUrl/$accountFrontEndRoute/start-a-return/nilReturn/false")
       .check(status.is(303))
       .check(saveCsrfToken())
+      .check(headerRegex(locationHeaderExpr, """.*/year/([0-9]{4})/quarter/[0-3]/nil-return/false""").saveAs("returnYear"))
+      .check(headerRegex(locationHeaderExpr, """.*/year/[0-9]{4}/quarter/([0-3])/nil-return/false""").saveAs("returnQuarter"))
       .check(header(locationHeaderExpr).transform(absoluteRedirectTransform(baseReturnsFrontEndUrl)).saveAs("startReturnUrl"))
 
   def getAccountHomePageStartReturn2: HttpRequestBuilder =

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnJourneyRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnJourneyRequests.scala
@@ -24,14 +24,10 @@ import uk.gov.hmrc.perftests.sdil.SetupRequests._
 
 trait SDILReturnJourneyRequests {
 
-  private val runLocal: Boolean = java.lang.Boolean.getBoolean("runLocal")
-
-  private val localSmallProducerCandidateRequests: Seq[HttpRequestBuilder] =
-    if (runLocal) {
-      smallProducerCandidates.zipWithIndex.map { case (sdilRef, index) =>
-        getSmallProducerCandidatePage(sdilRef, index)
-      }
-    } else Seq.empty
+  private val smallProducerCandidateRequests: Seq[HttpRequestBuilder] =
+    smallProducerCandidates.zipWithIndex.map { case (sdilRef, index) =>
+      getSmallProducerCandidatePage(sdilRef, index)
+    }
 
   val sdilReturnJourney1Requests: Seq[HttpRequestBuilder] = Seq(
     resetPending,
@@ -45,7 +41,7 @@ trait SDILReturnJourneyRequests {
     getAccountHomePage,
     getAccountHomePageStartReturn1,
     getAccountHomePageStartReturn2
-  ) ++ localSmallProducerCandidateRequests ++ Seq(
+  ) ++ smallProducerCandidateRequests ++ Seq(
     getOwnBrandsPackagedAtOwnSitesPage,
     postOwnBrandsPackagedAtOwnSitesPage,
     getHowManyOwnBrandsPackagedAtOwnSitesPage,
@@ -93,7 +89,7 @@ trait SDILReturnJourneyRequests {
     getAccountHomePage,
     getAccountHomePageStartReturn1,
     getAccountHomePageStartReturn2
-  ) ++ localSmallProducerCandidateRequests ++ Seq(
+  ) ++ smallProducerCandidateRequests ++ Seq(
     getOwnBrandsPackagedAtOwnSitesPage,
     postOwnBrandsPackagedAtOwnSitesPage,
     getHowManyOwnBrandsPackagedAtOwnSitesPage,

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnJourneyRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnJourneyRequests.scala
@@ -24,9 +24,19 @@ import uk.gov.hmrc.perftests.sdil.SetupRequests._
 
 trait SDILReturnJourneyRequests {
 
+  private val runLocal: Boolean = java.lang.Boolean.getBoolean("runLocal")
+
+  private val localSmallProducerCandidateRequests: Seq[HttpRequestBuilder] =
+    if (runLocal) {
+      smallProducerCandidates.zipWithIndex.map { case (sdilRef, index) =>
+        getSmallProducerCandidatePage(sdilRef, index)
+      }
+    } else Seq.empty
+
   val sdilReturnJourney1Requests: Seq[HttpRequestBuilder] = Seq(
     resetPending,
     resetReturns,
+    resetSubscriptions,
     sdilReturnsCollectionReset,
     resetReturnsUserAnswers(),
     navigateToAuth,
@@ -34,7 +44,8 @@ trait SDILReturnJourneyRequests {
     navigateToAuthSession,
     getAccountHomePage,
     getAccountHomePageStartReturn1,
-    getAccountHomePageStartReturn2,
+    getAccountHomePageStartReturn2
+  ) ++ localSmallProducerCandidateRequests ++ Seq(
     getOwnBrandsPackagedAtOwnSitesPage,
     postOwnBrandsPackagedAtOwnSitesPage,
     getHowManyOwnBrandsPackagedAtOwnSitesPage,
@@ -73,6 +84,7 @@ trait SDILReturnJourneyRequests {
   val sdilReturnJourney2Requests: Seq[HttpRequestBuilder] = Seq(
     resetPending,
     resetReturns,
+    resetSubscriptions,
     sdilReturnsCollectionReset,
     resetReturnsUserAnswers(),
     navigateToAuth,
@@ -80,7 +92,8 @@ trait SDILReturnJourneyRequests {
     navigateToAuthSession,
     getAccountHomePage,
     getAccountHomePageStartReturn1,
-    getAccountHomePageStartReturn2,
+    getAccountHomePageStartReturn2
+  ) ++ localSmallProducerCandidateRequests ++ Seq(
     getOwnBrandsPackagedAtOwnSitesPage,
     postOwnBrandsPackagedAtOwnSitesPage,
     getHowManyOwnBrandsPackagedAtOwnSitesPage,

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnsRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnsRequests.scala
@@ -17,8 +17,12 @@
 package uk.gov.hmrc.perftests.sdil
 
 import io.gatling.core.Predef._
+import io.gatling.commons.validation.SuccessWrapper
+import io.gatling.core.session.{Expression, Session}
 import io.gatling.http.Predef._
 import io.gatling.http.request.builder.HttpRequestBuilder
+
+import java.time.LocalDate
 
 object SDILReturnsRequests extends BaseRequest {
 
@@ -26,6 +30,43 @@ object SDILReturnsRequests extends BaseRequest {
   val returnsFrontEndRoute: String   = "soft-drinks-industry-levy-returns-frontend"
   val baseAccountFrontEndUrl: String = baseUrlFor("soft-drinks-industry-levy-account-frontend")
   val accountFrontEndRoute: String   = "soft-drinks-industry-levy-account-frontend"
+  private val runLocal: Boolean      = java.lang.Boolean.getBoolean("runLocal")
+  private lazy val baseStubUrl: String = baseUrlFor("soft-drinks-industry-levy-stub")
+
+  val smallProducerCandidates: Seq[String] = Seq(
+    "XQSDIL000000011",
+    "XTSDIL000000021",
+    "XYSDIL000000081",
+    "XZSDIL000000111",
+    "XWSDIL000000341"
+  )
+
+  private def candidateDateKey(index: Int): String = s"smallProducerCandidateDate$index"
+
+  private def returnPeriodEnd(year: Int, quarter: Int): LocalDate =
+    if (quarter == 3) LocalDate.of(year + 1, 1, 1).minusDays(1)
+    else LocalDate.of(year, quarter * 3 + 4, 1).minusDays(1)
+
+  private val smallProducerReferenceExpr: Expression[Any] = (session: Session) => {
+    val fallbackRef = smallProducerCandidates.last
+    val year        = session("returnYear").as[String].toInt
+    val quarter     = session("returnQuarter").as[String].toInt
+    val periodEnd   = returnPeriodEnd(year, quarter)
+
+    val validRef = smallProducerCandidates.zipWithIndex.collectFirst {
+      case (ref, index) if LocalDate.parse(session(candidateDateKey(index)).as[String]).isBefore(periodEnd) => ref
+    }
+
+    validRef.getOrElse(fallbackRef).success
+  }
+
+  def getSmallProducerCandidatePage(sdilRef: String, index: Int): HttpRequestBuilder =
+    http(s"GET small-producer-candidate-$sdilRef")
+      .get(s"$baseStubUrl/soft-drinks/subscription/details/sdil/$sdilRef")
+      .header("Authorization", "Bearer test")
+      .header("Environment", "live")
+      .check(status.is(200))
+      .check(jsonPath("$.subscriptionDetails.taxObligationStartDate").saveAs(candidateDateKey(index)))
 
   def redirectToBrandsPackagedAtOwnSitesPage: HttpRequestBuilder =
     http("REDIRECT to returns from accounts")
@@ -117,7 +158,7 @@ object SDILReturnsRequests extends BaseRequest {
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/add-small-producer")
       .formParam("csrfToken", csrfTokenExpr)
       .formParam("producerName", elAnyExpr("Fake Producer"))
-      .formParam("referenceNumber", elAnyExpr("XASDIL000000431"))
+      .formParam("referenceNumber", if (runLocal) smallProducerReferenceExpr else elAnyExpr("XWSDIL000000341"))
       .formParam("lowBand", elAnyExpr("1000"))
       .formParam("highBand", elAnyExpr("1000"))
       .check(status.is(303))

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnsRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnsRequests.scala
@@ -37,6 +37,9 @@ object SDILReturnsRequests extends BaseRequest {
     "XTSDIL000000021",
     "XYSDIL000000081",
     "XZSDIL000000111",
+    "XASDIL000000431",
+    "XHSDIL000000921",
+    "XPSDIL000000161",
     "XWSDIL000000341"
   )
 

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnsRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SDILReturnsRequests.scala
@@ -30,7 +30,6 @@ object SDILReturnsRequests extends BaseRequest {
   val returnsFrontEndRoute: String   = "soft-drinks-industry-levy-returns-frontend"
   val baseAccountFrontEndUrl: String = baseUrlFor("soft-drinks-industry-levy-account-frontend")
   val accountFrontEndRoute: String   = "soft-drinks-industry-levy-account-frontend"
-  private val runLocal: Boolean      = java.lang.Boolean.getBoolean("runLocal")
   private lazy val baseStubUrl: String = baseUrlFor("soft-drinks-industry-levy-stub")
 
   val smallProducerCandidates: Seq[String] = Seq(
@@ -158,7 +157,7 @@ object SDILReturnsRequests extends BaseRequest {
       .post(s"$baseReturnsFrontEndUrl/$returnsFrontEndRoute/add-small-producer")
       .formParam("csrfToken", csrfTokenExpr)
       .formParam("producerName", elAnyExpr("Fake Producer"))
-      .formParam("referenceNumber", if (runLocal) smallProducerReferenceExpr else elAnyExpr("XWSDIL000000341"))
+      .formParam("referenceNumber", smallProducerReferenceExpr)
       .formParam("lowBand", elAnyExpr("1000"))
       .formParam("highBand", elAnyExpr("1000"))
       .check(status.is(303))

--- a/src/test/scala/uk/gov/hmrc/perftests/sdil/SetupRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/sdil/SetupRequests.scala
@@ -44,6 +44,10 @@ object SetupRequests extends BaseRequest {
     http("GET reset-returns")
       .get(s"$baseBackendUrl/$backendRoute/reset-returns")
 
+  def resetSubscriptions: HttpRequestBuilder =
+    http("GET reset-subscriptions")
+      .get(s"$baseBackendUrl/$backendRoute/reset-subscriptions")
+
   def resetRegistrations: HttpRequestBuilder =
     http("GET reset-registrations")
       .get(s"$baseBackendUrl/$backendRoute/reset-registrations")


### PR DESCRIPTION
Fix unstable small producer ref in returns PT by clearing stale data and selecting a valid local ref dynamically instead of updating the hardcoded ref each time